### PR TITLE
Set state v2

### DIFF
--- a/examples/Example1.purs
+++ b/examples/Example1.purs
@@ -35,7 +35,7 @@ type MyProtocol
       ( state1 ::
           P.State
             ( action1 :: P.Action Nil'
-            , action2 :: P.Action ("state2" :> "state1" :> Nil')
+            , action2 :: P.Action ("state2" :> Nil')
             )
       , state2 :: P.State ()
       )
@@ -46,10 +46,13 @@ type MyStateMachine
 check :: Unit
 check = STM.validate (Proxy :: _ MyStateMachine)
 
-_state1 :: forall a v. a -> Variant ( state1 :: a | v )
-_state1 = inj (Proxy :: _ "state1")
+_state1 :: forall a v. a -> Variant ( state2 :: a | v )
+_state1 = inj (Proxy :: _ "state2")
 
-myControl :: forall m. Monad m => (MyState -> m Unit) -> MyState -> MyAction -> m Unit
+__state1 :: Proxy "state2"
+__state1 = Proxy :: _ "state2"
+
+myControl :: forall m. Monad m => ((MyState -> MyState) -> m Unit) -> MyState -> MyAction -> m Unit
 myControl =
   C.mkControl (Proxy :: _ MyStateMachine)
     { state1:
@@ -58,6 +61,9 @@ myControl =
               pure unit
         , action2:
             \setState _ _ -> do
+              setState (\_ -> inj __state1 "sss")
+              setState (\_ -> _state1 "sss")
+              -- setState.state1 "foooo"
               -- setState (inj (Proxy :: _ "state1") 12)
               -- setState.state1 12
               -- setState (inj _state1 12)
@@ -90,7 +96,11 @@ type Surface a
 --                 "n" -> _no
 --                 _ -> _wrongInput
 --           }
---     }
+-- --     }
+-- type RS a
+--   = (a -> Unit) -> JSX
+stmProxy = Proxy :: _ MyStateMachine
+
 main :: Effect Unit
 main =
   R.reflectStateMachine (Proxy :: _ MyStateMachine)

--- a/spago.dhall
+++ b/spago.dhall
@@ -16,6 +16,7 @@ to generate this file without the comments in this block.
   , "console"
   , "effect"
   , "foldable-traversable"
+  , "identity"
   , "maybe"
   , "node-buffer"
   , "node-fs"

--- a/src/Stadium/Control.js
+++ b/src/Stadium/Control.js
@@ -2,7 +2,13 @@ exports.mkControlImpl = function (spec) {
     return function (setState) {
         return function (st) {
             return function (ac) {
-                return spec[st.type][ac.value.type](setState)(st.value)(ac.value.value)
+                let setState_ = function (f) {
+                    let f_ = function (x) {
+                        return f(x.value)
+                    }
+                    return setState(f_)
+                };
+                return spec[st.type][ac.value.type](setState_)(st.value)(ac.value.value)
             }
         }
     }

--- a/src/Stadium/Control.js
+++ b/src/Stadium/Control.js
@@ -3,7 +3,8 @@ exports.mkControlImpl = function (spec) {
         return function (st) {
             return function (ac) {
                 var setState_ = function (f) {
-                    var f_ = function (_) {
+                    var f_ = function (x) {
+                        console.log({ x, st, ac })
                         return f(st.value)
                     }
                     return setState(f_)

--- a/src/Stadium/Control.js
+++ b/src/Stadium/Control.js
@@ -4,8 +4,7 @@ exports.mkControlImpl = function (spec) {
             return function (ac) {
                 var setState_ = function (f) {
                     var f_ = function (x) {
-                        console.log({ x, st, ac })
-                        return f(st.value)
+                        return f(x.value)
                     }
                     return setState(f_)
                 };

--- a/src/Stadium/Control.js
+++ b/src/Stadium/Control.js
@@ -2,9 +2,9 @@ exports.mkControlImpl = function (spec) {
     return function (setState) {
         return function (st) {
             return function (ac) {
-                let setState_ = function (f) {
-                    let f_ = function (x) {
-                        return f(x.value)
+                var setState_ = function (f) {
+                    var f_ = function (_) {
+                        return f(st.value)
                     }
                     return setState(f_)
                 };

--- a/src/Stadium/Control.purs
+++ b/src/Stadium/Control.purs
@@ -164,19 +164,20 @@ tests =
           myStateM :: State MyState Unit
           myStateM = myControl modify_ (_state1 5) (_state1' $ _action1 10)
         A.equal (_state1 15) (execState myStateM myInit)
-  -- T.test "setState as function" do
-  --   let
-  --     myControl :: forall m. Monad m => ((MyState -> MyState) -> m Unit) -> MyState -> MyAction -> m Unit
-  --     myControl =
-  --       mkControl (Proxy :: _ MyStateMachine)
-  --         { state1:
-  --             { action1:
-  --                 \setState _ a -> setState (\s -> _state1 (s + a))
-  --             }
-  --         }
-  --     myStateM :: State MyState Unit
-  --     myStateM = myControl modify_ (_state1 5) (_state1' $ _action1 10)
-  --   A.equal (_state1 15) (execState myStateM myInit)
+      T.test "setState as function" do
+        let
+          myControl :: forall m. Monad m => ((MyState -> MyState) -> m Unit) -> MyState -> MyAction -> m Unit
+          myControl =
+            mkControl (Proxy :: _ MyStateMachine)
+              { state1:
+                  { action1:
+                      \setState _ a -> setState (\s -> _state1 (s + a))
+                  }
+              }
+
+          myStateM :: State MyState Unit
+          myStateM = myControl modify_ (_state1 5) (_state1' $ _action1 10)
+        A.equal (_state1 15) (execState myStateM myInit)
   where
   _action1 = inj (Proxy :: _ "action1")
 


### PR DESCRIPTION
- This is the implementation that we finally used yesterday
- plus the second test case is now back and working with this implementation.

![Screenshot from 2022-02-24 08-47-36](https://user-images.githubusercontent.com/18749447/155480758-dc8e46b2-0327-4097-b565-2459305ad697.png)


Now I realize we did not merge `implement-mk-control` yet. this branch is based on it, that's why the diff is larger.
I suggest it's the easiest to merge it at once with this PR.

